### PR TITLE
fixed typeDefs date to string & added user to Query

### DIFF
--- a/client/src/components/Twit.jsx
+++ b/client/src/components/Twit.jsx
@@ -1,0 +1,7 @@
+function Twit() {return(
+    <div>
+        <p></p>
+    </div>
+)};
+
+export default Twit;

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -1,5 +1,6 @@
 const { gql } = require('apollo-server-express');
 
+
 const typeDefs = gql`
   type User {
     _id: ID
@@ -7,6 +8,7 @@ const typeDefs = gql`
     password: String
     email: String
     tweeterYellow: Boolean
+    createdAt: String
     twits: [Twit]!
   }
 
@@ -17,8 +19,8 @@ const typeDefs = gql`
     thumbsUp: Int
     thumbsDown: Int
     retwitCounter: Int
-    createdAt: Date
-    updatedAt: Date
+    createdAt: String
+    updatedAt: String
     comments: [Comment]!
   }
 
@@ -29,8 +31,8 @@ const typeDefs = gql`
     commentText: String
     thumbsUp: Int
     thumbsDown: Int
-    createdAt: Date
-    updatedAt: Date
+    createdAt: String
+    updatedAt: String
   }
 
   type Auth {
@@ -41,6 +43,7 @@ const typeDefs = gql`
   type Query {
     twits: [Twit]
     userTwits(userId: ID!): [Twit]
+    users: [User]
   }
 
   type Mutation {

--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const path = require('path');
 // apollo server
 const { ApolloServer } = require('apollo-server-express');
+
 // database connection
 const db = require('./config/connection');
 
@@ -14,7 +15,7 @@ const PORT = process.env.PORT || 3001;
 // new apollo server
 const server = new ApolloServer({
   typeDefs,
-  resolvers,
+  resolvers
 });
 
 // middlewares

--- a/server/utils/dateScalar.js
+++ b/server/utils/dateScalar.js
@@ -1,0 +1,14 @@
+const { GraphQLScalarType } = require('graphql');
+
+// create scalar date
+const dateScalar = new GraphQLScalarType({
+  name: 'Date',
+  parseValue(value) {
+    return new Date(value);
+  },
+  serialize(value) {
+    return value.toISOString();
+  }
+})
+
+module.exports = dateScalar;


### PR DESCRIPTION
## Purpose

Fixes #[13]

Changed type "date" to "string" in typeDefs because date isn't a primitive type GraphQL supports. Max tried to use a GraphQL scalar type to define what a date should be but that didn't work. We also added a definition of "user" to the users Query so server would run.

## Changes

Changes to typeDefs.js


